### PR TITLE
Master

### DIFF
--- a/XBOX360.ahk
+++ b/XBOX360.ahk
@@ -120,6 +120,26 @@ Class Xbox360LibXInput {
     GetBatteryInformation(index, type, batteryOutAddress) {
         return DllCall(this.getBatteryInformationAddress, "UInt", index, "UChar", type, "UPtr", batteryOutAddress)
     }
+ 
+    /**
+     * @return int
+     */ 
+	GetGamepadBatteryLevelValue(index) {
+		VarSetCapacity(batteryOutAddress, 2)
+		if (this.GetBatteryInformation(index, 0, &batteryOutAddress) == 0)
+			return NumGet(batteryOutAddress, 1, "UChar")
+		else
+			return -1   ; -1 for "Unknown", different to 0 for "Empty"
+	}
+    
+    /**
+     * @return string
+     */
+    GetGamepadBatteryLevelName(index) {
+        static names := {-1: "Unknown", 0: "Empty", 1: "Low", 2: "Medium", 3: "Full"}
+        return names[this.GetGamepadBatteryLevelValue(index)]
+    }
+    
     /**
      * @return int
      */

--- a/XBOX360.ahk
+++ b/XBOX360.ahk
@@ -118,7 +118,7 @@ Class Xbox360LibXInput {
      * @return int
      */
     GetBatteryInformation(index, type, batteryOutAddress) {
-        return DllCall(this.getBatteryInformationAddress, , "UInt", index, "UChar", type, "UPtr", batteryOutAddress)
+        return DllCall(this.getBatteryInformationAddress, "UInt", index, "UChar", type, "UPtr", batteryOutAddress)
     }
     /**
      * @return int

--- a/examples/readme.ahk
+++ b/examples/readme.ahk
@@ -125,7 +125,8 @@ Loop {
     leftMotorSpeed := Ceil((Abs(player1.LSY) + Abs(player1.LSX)) / 64932 * 65532)
     rightMotorSpeed := Ceil((Abs(player1.RSY) + Abs(player1.RSX)) / 64932 * 65532)
     player1.BV := [leftMotorSpeed, rightMotorSpeed]
-    
+    if (msg)
+        msg .= "Player One Battery Level: " manager.xinput.GetGamepadBatteryLevelName(0) "`n"
     ToolTip, %msg%
     Sleep 5
 }


### PR DESCRIPTION
Corrects typo in DllCall for GetBatteryInformation (extra comma)

Adds GetGamepadBatteryLevelValue, GetGamepadBatteryLevelName functions to get battery level of the gamepad, both as values (-1 for "Unknown", 0 for "None", 1 for "Low", 2 for "Medium", 3 for "Full") or as the names
